### PR TITLE
Assignee 설정 자동화

### DIFF
--- a/.github/automation.yaml
+++ b/.github/automation.yaml
@@ -1,0 +1,13 @@
+name: 🤖 Automation
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
https://github.com/DaleStudy/leetcode-study/pull/26#issuecomment-2079490643 에서 논의되었던 것처럼, 현재 권한 문제로 코드 작성자가 스스로 자신을 Pull Request에 Assignee로 설정할 수가 없습니다. 기여자 경험을 개선하고 관리자가 일일이 Assignee를 설정하는 수고가 없도록, GitHub Actions에 자동화 워크플로우를 추가하려고 합니다. 이 PR이 main 브랜치에 머지되면, Pull Reqeust에 Assignee가 자동으로 설정이 될 것입니다.