### PR TITLE
[Hyun] Week 4 Solution Explanation

### DIFF
--- a/counting-bits/WhiteHyun.swift
+++ b/counting-bits/WhiteHyun.swift
@@ -1,0 +1,27 @@
+//  
+//  338. Counting Bits
+//  https://leetcode.com/problems/counting-bits/description/
+//  Dale-Study
+//  
+//  Created by WhiteHyun on 2024/05/19.
+//  
+
+final class Solution {
+
+  // MARK: - Time Complexity: O(n), Space Complexity: O(n)
+
+  func countBits(_ n: Int) -> [Int] {
+    var array: [Int] = .init(repeating: 0, count: n + 1)
+    for i in stride(from: 1, through: n, by: 1) {
+      array[i] = array[i >> 1] + (i & 1)
+    }
+    return array
+  }
+
+  // MARK: - nonzeroBitCount
+
+  func countBits2(_ n: Int) -> [Int] {
+    return (0...n).map(\.nonzeroBitCount)
+  }
+
+}

--- a/group-anagrams/WhiteHyun.swift
+++ b/group-anagrams/WhiteHyun.swift
@@ -1,0 +1,18 @@
+//  
+//  49. Group Anagrams
+//  https://leetcode.com/problems/group-anagrams/description/
+//  Dale-Study
+//  
+//  Created by WhiteHyun on 2024/05/19.
+//  
+
+final class Solution {
+  func groupAnagrams(_ strs: [String]) -> [[String]] {
+    var dictionary: [String: [String]] = [:]
+    for str in strs {
+      dictionary[String(str.sorted()), default: []].append(str)
+    }
+
+    return Array(dictionary.values)
+  }
+}

--- a/missing-number/WhiteHyun.swift
+++ b/missing-number/WhiteHyun.swift
@@ -10,4 +10,21 @@ final class Solution {
   func missingNumber(_ nums: [Int]) -> Int {
     (0 ... nums.count).reduce(0, +) - nums.reduce(0, +)
   }
+
+  func missingNumber2(_ nums: [Int]) -> Int {
+    nums.count * (nums.count + 1) / 2 - nums.reduce(0, +)
+  }
+
+  func missingNumber3(_ nums: [Int]) -> Int {
+    Set(0...nums.count).subtracting(Set(nums)).first!
+  }
+
+  func missingNumber4(_ nums: [Int]) -> Int {
+    var answer = 0
+    for i in 0 ..< nums.count {
+      answer = answer ^ i ^ nums[i]
+    }
+
+    return answer ^ nums.count
+  }
 }

--- a/missing-number/WhiteHyun.swift
+++ b/missing-number/WhiteHyun.swift
@@ -1,0 +1,13 @@
+//  
+//  268. Missing Number
+//  https://leetcode.com/problems/missing-number/description/
+//  Dale-Study
+//  
+//  Created by WhiteHyun on 2024/05/19.
+//  
+
+final class Solution {
+  func missingNumber(_ nums: [Int]) -> Int {
+    (0 ... nums.count).reduce(0, +) - nums.reduce(0, +)
+  }
+}

--- a/number-of-1-bits/WhiteHyun.swift
+++ b/number-of-1-bits/WhiteHyun.swift
@@ -1,0 +1,13 @@
+//  
+//  191. Number of 1 Bits
+//  https://leetcode.com/problems/number-of-1-bits/description/
+//  Dale-Study
+//  
+//  Created by WhiteHyun on 2024/05/19.
+//  
+
+final class Solution {
+  func hammingWeight(_ n: Int) -> Int {
+    n.nonzeroBitCount
+  }
+}

--- a/number-of-1-bits/WhiteHyun.swift
+++ b/number-of-1-bits/WhiteHyun.swift
@@ -10,4 +10,15 @@ final class Solution {
   func hammingWeight(_ n: Int) -> Int {
     n.nonzeroBitCount
   }
+  
+  func hammingWeight2(_ n: Int) -> Int {
+    var number = n
+    var answer = 0
+    while number != 0 {
+      answer += number & 1
+      number >>= 1
+    }
+
+    return answer
+  }
 }

--- a/reverse-bits/WhiteHyun.swift
+++ b/reverse-bits/WhiteHyun.swift
@@ -1,0 +1,28 @@
+//  
+//  190. Reverse Bits
+//  https://leetcode.com/problems/reverse-bits/description/
+//  Dale-Study
+//  
+//  Created by WhiteHyun on 2024/05/19.
+//  
+
+final class Solution {
+
+  // MARK: - Runtime: 5ms / Memory 16.12 MB
+
+  func reverseBits(_ n: Int) -> Int {
+    let reversedStringBits = String(String(n, radix: 2).reversed())
+    return Int(reversedStringBits + String(repeating: "0", count: 32 - reversedStringBits.count), radix: 2)!
+  }
+
+  // MARK: - Runtime: 5ms / Memory 15.72 MB
+
+  func reverseBits2(_ n: Int) -> Int {
+    var answer = 0
+
+    for index in 0 ..< 32 {
+      answer += ((n >> (32 - index - 1)) & 1) << index
+    }
+    return answer
+  }
+}


### PR DESCRIPTION
## 49. Group Anagrams

### Complexities 📈

- Time Complexity: $O(n * m log m)$ (m = string length, n = string array's length)
- Space Complexity: $O(n)$

### Explanation 📝

1. 처음 접근할 때 단순히 Set 타입으로 묶어 Dictionary의 key값으로 제공함
2. `"good"`과 `"god"`이 같이 묶이는 문제점을 발견
3. Set 대신에 정렬된 배열값을 key로 하여 Dictionary에 추가

- [Test code](https://github.com/WhiteHyun/Algorithm-Journey/blob/main/swift/AlgorithmTests/LeetCode/LeetCode49Tests.swift)

## 190. Reverse Bits

### Complexities 📈

- Time Complexity: $O(1)$
- Space Complexity: $O(1)$

### Explanation 📝

1. 처음에 두 가지의 접근 방식이 떠오름
   a. 2진수를 문자열로 변환 → 문자열을 거꾸로 변환 → prefix가 0이어서 축약된 길이만큼 suffix에 0을 확장 → 정수타입으로 변환 및 리턴
   b. 각 비트마다 쉬프트 연산(`<<`, `>>`)과 앤드 연산(`&`)을 활용하여 더하고 리턴
2. 전부 구현하고 시간차를 확인해보았으나, 32자리수를 처리하는 것에 대해 시간 계산은 유의미한 차이를 찾지 못함

- [Test code](https://github.com/WhiteHyun/Algorithm-Journey/blob/main/swift/AlgorithmTests/LeetCode/LeetCode190Tests.swift)

## 191. Number of 1 Bits

### Complexities 📈

- Time Complexity: $O(1)$
- Space Complexity: $O(1)$

### Explanation 📝

|                                                                              Results                                                                               |
| :----------------------------------------------------------------------------------------------------------------------------------------------------------------: |
| <img width="754" alt="Screenshot 2024-05-24 at 3 51 10 PM" src="https://github.com/DaleStudy/leetcode-study/assets/57972338/c414295f-d468-4f03-ba24-8e75bba7cc34"> |

- Swift에는 Int타입의 메서드로 `nonzeroBitCount`라는 프로퍼티가 존재함, 이는 Swift에서 자체 제공해주는 프로퍼티로, 실제 비트 중 1의 총 개수를 리턴함
- Swift에서 제공해주는 것을 사용하지 않을 경우도 구현하였고, 비교 결과 유의미한 차이는 존재하지 않았음

- [Test code](https://github.com/WhiteHyun/Algorithm-Journey/blob/main/swift/AlgorithmTests/LeetCode/LeetCode191Tests.swift)

## 268. Missing Number

### Complexities 📈

- Time Complexity: $O(n)$
- Space Complexity: $O(1)$

### Explanation 📝

|                                                                              Results                                                                               |
| :----------------------------------------------------------------------------------------------------------------------------------------------------------------: |
| <img width="752" alt="Screenshot 2024-05-24 at 4 09 41 PM" src="https://github.com/DaleStudy/leetcode-study/assets/57972338/cb830db8-127a-4bc5-8283-3b78a28f1f9a"> |

[0 ... n]에서 생략된 숫자를 구해야 함

1. 세 가지의 방법이 떠오름

   1. XOR로 풀이
   2. [0 ... n]의 총합과 주어진 숫자 배열의 총합을 빼는 풀이
   3. Set로 묶어서 차집합 연산

2. 전부 구현 후 시간 비교 결과, 짧은 풀이이기 때문에 실행 환경에 따라 속도가 달라졌음

- [Test code](https://github.com/WhiteHyun/Algorithm-Journey/blob/main/swift/AlgorithmTests/LeetCode/LeetCode268Tests.swift)

## 338. Counting Bits

### Complexities 📈

- Time Complexity: $O(n)$
- Space Complexity: $O(n)$

### Explanation 📝

|                                                               Results                                                                |
| :----------------------------------------------------------------------------------------------------------------------------------: |
| <img width="418" alt="image" src="https://github.com/DaleStudy/leetcode-study/assets/57972338/92439c53-e3e5-432a-9888-456f73712dbf"> |

1. 처음에는 Swift에서 자체제공해주는 `nonzeroBitCount` 프로퍼티를 사용하여 풀이함
2. 하지만 dp로 풀이할 수 있다는 사실을 깨닫고 새롭게 풀이함

   1. `6(110)`은 `3(11)`의 1의 개수 + `6(110)`의 최하위 비트,
   2. `3(11)`은 `1(1)`의 1의 개수 + `3(11)`의 최하위 비트,
   3. ...

   - 즉 점화식은 아래와 같음

$$
a_n=
\begin{cases}
a_\frac{n}{2} + (n \land 1) \text{ for } n \geq 2 \\
a_1=1 \\
a_0=0
\end{cases}
$$

3. LeetCode에서 주어진 테스트케이스로는 시간 계산이 어렵다고 판단하여 `10_000_000`의 값을 주고 풀이 속도 측정, dp 풀이가 확실히 빨랐음(어찌보면 당연한 거일 수도....)

- [Test code](https://github.com/WhiteHyun/Algorithm-Journey/blob/main/swift/AlgorithmTests/LeetCode/LeetCode338Tests.swift)
