### PR TITLE
ci: add permissions for pr labels

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -3,6 +3,10 @@ name: 🔄 Integration
 on:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   linelint:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -85,5 +85,5 @@ jobs:
             }
           }
 
-          run().catch(err => console.error(err));
+          run();
           "


### PR DESCRIPTION
## 배경
- label 추가 단계에서 [403 Forbidden 오류](https://github.com/DaleStudy/leetcode-study/actions/runs/10473144974/job/29004343723) 발생
    ![image](https://github.com/user-attachments/assets/d8f82222-f49c-4828-b2de-91c571988016)
- job 이 실패하였음에도 catch 블록으로 인해 오류를 인지하지 못하는 문제 발생

## 작업
- contents 및 pull-requests 에 대해 `write` 권한을 부여하여 label 을 추가할 수 있도록 함
- catch 블록을 제거하여 단계가 실패하였음을 인지할 수 있도록 함 
