### PR TITLE
ci: add pr langauge labeler on `pull_request_target` event

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,4 +41,4 @@ go:
 elixir:
   - changed-files:
       - any-glob-to-any-file:
-          - "**/*.ex"
+          - "**/*.exs"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,44 @@
+js:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.js"
+
+ts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.ts"
+
+py:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.py"
+
+java:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.java"
+
+c++:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.cpp"
+
+swift:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.swift"
+
+kotlin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.kt"
+
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.go"
+
+elixir:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.ex"

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -11,3 +11,16 @@ jobs:
       pull-requests: write
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0
+
+  label-lang:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
## 배경

- Fixes: #368
- 2024-08-25(일) 정기 스터디 모임 이후 운영진들과 나눈 대화에서 labeler 를 `pull_request_target` 이벤트를 사용하여 해결해보기로 결정.
- 자체 테스트를 해보니 직접 구현하는 방법도 좋지만, @DaleSeo 님, @sounmind 님이 이 알려주신 GitHub Actions 의 `actions/labeler` 를 사용하는 게 더 깔끔한 구현이 가능하여 이를 사용하여 작업 진행. 
  - @sounmind 의 [예제 작업](https://github.com/DaleStudy/leetcode-study/pull/372) 잘 참고하였습니다. 감사합니다 에반님! 그리고 가이드 주셔서 감사합니다 달레님! 🙇

## 작업

- [actions/labeler](https://github.com/actions/labeler) 의 사용법대로, `.github/labeler.yml` 에 원하는 조건과 label 구성을 정의
- `pull_request_target` 이벤트 기반으로 작성하던 기존 `automation` 이벤트에 `label-lang` job 새로 추가

## 테스트

- [지난 번](https://github.com/DaleStudy/leetcode-study/pull/335)과 달리 이번에는 `fork` repository 에서 base repository 로 PR 을 열어 테스트를 진행함. 
- 테스트 수행 결과 -> 정상 작동 확인 
    ![image](https://github.com/user-attachments/assets/623b99fb-f35a-4ec3-9c2d-3bc1cf31f124)

> [!NOTE]
> `pull_request_target` 는 `pull_request` 와 달리, base repo의 컨텍스트를 기반으로 작동하기 때문에 main 에 병합된 이후 올라온 PR 부터 automation 이 작동합니다.
