### PR TITLE
ci: ignore line lint for empty files, add C/C# labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,10 +18,20 @@ java:
       - any-glob-to-any-file:
           - "**/*.java"
 
+c:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.c"
+
 c++:
   - changed-files:
       - any-glob-to-any-file:
           - "**/*.cpp"
+
+c#:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.cs"
 
 swift:
   - changed-files:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,7 +16,7 @@ jobs:
           files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
           success=true
           for file in $files; do
-            if [ "$(tail -c 1 $file | wc -l)" -eq 0 ]; then
+            if [ -s "$file" ] && [ "$(tail -c 1 $file | wc -l)" -eq 0 ]; then
               echo "- $file" >> $GITHUB_STEP_SUMMARY
               success=false
             fi


### PR DESCRIPTION
## 작업 내용
- 빈 파일에 대한 line lint 체크를 무시하도록 수정했습니다.
  - GitHub 에서도 개행 체크를 하지 않으니 통합 워크플로에서도 검사를 수행하지 않기로 @DaleSeo 님과 이야기를 나누었습니다.
- `C` 및 `C#` 파일에 대한 라벨 설정을 추가했습니다.
  -  아직 소수의 인원이 사용하지만, 알고리즘에 c 계열 언어를 지원하는 경우가 굉장히 많고, 이곳 Repository 가 다양한 언어를 수용하는 곳이기 때문에 추가해두었습니다.

## 테스트
> 아래 테스트는 제 개인 Repo 에서 진행하였습니다.
- 빈 파일에 대한 line lint 체크를 무시하도록 수정했습니다.
  - **변경 전: 워크플로 실패 및 Summary 존재**
    - PR 하단
      ![image](https://github.com/user-attachments/assets/35e4bf72-218a-402d-b2b0-a15d2fb30d51)
    - GitHub Actions Summary 
      ![image](https://github.com/user-attachments/assets/e71020f7-6f30-4243-a54d-c0a408fad5b9)
  - **변경 후: 워크플로 성공 및 Summary 없음**
      ![image](https://github.com/user-attachments/assets/4d8de76d-1db3-4225-bf6f-192c644369ab)
- `C` 및 `C#` 파일에 대한 라벨 설정을 추가했습니다.
    ![image](https://github.com/user-attachments/assets/dd5cf01b-c451-43ce-9dc6-a538208ba85e)

