### PR TITLE
ci: add assign-reviewer job

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -37,10 +37,10 @@ jobs:
 
           # 최근 3개의 PR 중 현재 PR 작성자와 다른 작성자 찾기
           previous_pr_author=$(gh pr list --repo $current_repo \
-            --search "number:<$current_pr_num -is:closed sort:created-desc -author:$current_pr_author" \
-            --limit 3 --json author \
-            --jq '.[0].author.login')
-
+            --search "-is:closed sort:created-desc -author:$current_pr_author" \
+            --limit 3 --json number,author \
+            --jq 'map(select(.number < '$current_pr_num'))[0].author.login')
+          
           if [ -n "$previous_pr_author" ]; then
             gh pr edit $current_pr_num --repo $current_repo --add-reviewer $previous_pr_author
           else

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -38,7 +38,7 @@ jobs:
           # 최근 3개의 PR 중 현재 PR 작성자와 다른 작성자 찾기
           previous_pr_author=$(gh pr list --repo $current_repo \
             --search "number:<$current_pr_num -is:closed sort:created-desc -author:$current_pr_author" \
-            --limit 3 --json number,author \
+            --limit 3 --json author \
             --jq '.[0].author.login')
 
           if [ -n "$previous_pr_author" ]; then

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -35,11 +35,13 @@ jobs:
           current_repo=${{ github.repository }}
           current_pr_num=${{ github.event.number }}
 
-          # 최근 3개의 PR 중 현재 PR 작성자와 다른 작성자 찾기
+          # 직전 PR 중에서 현재 PR 작성자와 다른 작성자 찾기
           previous_pr_author=$(gh pr list --repo $current_repo \
-            --search "-is:closed sort:created-desc -author:$current_pr_author" \
-            --limit 3 --json number,author \
-            --jq 'map(select(.number < '$current_pr_num'))[0].author.login')
+            --state all \
+            --search "created:<${{ github.event.pull_request.created_at }} sort:created-desc -author:${{ github.actor }}" \
+            --limit 3 \
+            --json number,author \
+            --jq "map(select(.number < $current_pr_num))[0].author.login")
           
           if [ -n "$previous_pr_author" ]; then
             gh pr edit $current_pr_num --repo $current_repo --add-reviewer $previous_pr_author

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -24,3 +24,26 @@ jobs:
       - uses: actions/labeler@v5
         with:
           repo-token: ${{ github.token }}
+
+  assign-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get previous PR author and assign as reviewer
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          current_repo=${{ github.repository }}
+          current_pr_num=${{ github.event.number }}
+
+          # 최근 3개의 PR 중 현재 PR 작성자와 다른 작성자 찾기
+          previous_pr_author=$(gh pr list --repo $current_repo \
+            --search "number:<$current_pr_num -is:closed sort:created-desc -author:$current_pr_author" \
+            --limit 3 --json number,author \
+            --jq '.[0].author.login')
+
+          if [ -n "$previous_pr_author" ]; then
+            gh pr edit $current_pr_num --repo $current_repo --add-reviewer $previous_pr_author
+          else
+            echo "❌ No previous PR author found to assign as reviewer"
+            exit 1
+          fi

--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -35,7 +35,7 @@ jobs:
           current_repo=${{ github.repository }}
           current_pr_num=${{ github.event.number }}
 
-          # 직전 PR 중에서 현재 PR 작성자와 다른 작성자 찾기
+          # 이전 PR 중에서 현재 PR 작성자와 다른 작성자 찾기
           previous_pr_author=$(gh pr list --repo $current_repo \
             --state all \
             --search "created:<${{ github.event.pull_request.created_at }} sort:created-desc -author:${{ github.actor }}" \

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .DS_Store
 .env
+**/*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .vscode/
 .DS_Store
 .env
-**/*.iml


### PR DESCRIPTION
## 배경

![image](https://github.com/user-attachments/assets/11a34560-b107-4597-8283-ab551005aaeb)

## 작업 내용

- GitHub CLI 를 사용하여 PR 리뷰어를 자동 할당하는 automation job 을 추가합니다.
- 리뷰어 조회 조건
  - ~Closed PR 은 제외함 (실수로 올렸다 닫는 경우가 종종 있으므로) -> opened, merged PR 만 조회~ (하단 코멘트 참고)
  - 찾은 PR 중 현재 PR에 가장 근접한 PR의 작성자여야 함 (created 로 역순 정렬)
  - 현재 PR과 다른 이름의 작성자여야 함
  - 현재 PR 보다 이전에 생성된 PR의 작성자여야 함
```
previous_pr_author=$(gh pr list --repo $current_repo \
            --search "-is:closed sort:created-desc -author:$current_pr_author" \
            --limit 3 --json number,author \
            --jq 'map(select(.number < '$current_pr_num'))[0].author.login')
```            
- 그외 .gitignore 업데이트

## 테스트

![image](https://github.com/user-attachments/assets/33a2eeab-e5de-449e-b800-dc80ff2f5318)


## 한계

- 현재 PR처럼 문제풀이와 상관없는 PR이 올라올 경우에도, 마지막 PR 작성자를 리뷰어로 할당받게 됨. (지금은 merge가 안됐기 때문에 적용되진 않지만) 
- 새로운 기수가 처음 등록하는 PR 에서는 직전 기수의 마지막 PR 작성자를 리뷰어로 할당받게 됨.
> 위 두 문제는 식별가능한 label 을 미리 설정하는 것으로 해결할 수 있을 것 같지만 그렇게 하기엔 손이 많이 가서 우선 보류합니다..