### PR TITLE
Revert "ci: add assign-reviewer job (#529)"

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -24,28 +24,3 @@ jobs:
       - uses: actions/labeler@v5
         with:
           repo-token: ${{ github.token }}
-
-  assign-reviewer:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get previous PR author and assign as reviewer
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          current_repo=${{ github.repository }}
-          current_pr_num=${{ github.event.number }}
-
-          # 이전 PR 중에서 현재 PR 작성자와 다른 작성자 찾기
-          previous_pr_author=$(gh pr list --repo $current_repo \
-            --state all \
-            --search "created:<${{ github.event.pull_request.created_at }} sort:created-desc -author:${{ github.actor }}" \
-            --limit 3 \
-            --json number,author \
-            --jq "map(select(.number < $current_pr_num))[0].author.login")
-          
-          if [ -n "$previous_pr_author" ]; then
-            gh pr edit $current_pr_num --repo $current_repo --add-reviewer $previous_pr_author
-          else
-            echo "❌ No previous PR author found to assign as reviewer"
-            exit 1
-          fi


### PR DESCRIPTION
## 배경

- [리소스 접근 제한 오류](https://github.com/DaleStudy/leetcode-study/actions/runs/11762079562/job/32764590050) 발생
    - `error fetching organization teams: GraphQL: Resource not accessible by integration (organization.teams)`
    ![image](https://github.com/user-attachments/assets/128104ce-67f4-487e-af1f-c5b1c7d538b6)

## 관련 이슈
- `gh pr edit --add-reviewer` 를 수행할 때, `organization teams` 를 읽는 과정이 포함되는데, 기본 제공하는 GitHub Actions Token 이 이 권한을 갖지 못하는 것으로 보임
- `organization teams` 를 획득하지 않고 `--add-reviewer` 동작을 수행하는 것 관련해서 이슈가 제기된 바 있음
  - 이슈: https://github.com/cli/cli/issues/4844
- 관련하여 해결 [PR](https://github.com/cli/cli/pull/9037)이 열려있지만 아직 병합되지는 않았고, 작성 시기나 피드백 시기를 보았을 때 해결 우선순위가 높아보이지 않음 -> 현재 레포에서는 작업을 revert 하는 게 좋아 보임

## 작업 내용
- https://github.com/DaleStudy/leetcode-study/pull/529 작업을 revert 함

## 확인 필요
- 개인적으로 테스트하였을 때는 정상적으로 동작을 수행했는데, 권한 설정을 모두 차단(혹은 최소화)한 후 위 이슈 코멘트의 대안을 수행하거나, 다른 대안을 찾아볼 필요가 있음 