### PR TITLE
Chore: integration workflow에 답안 파일 명을 "GitHub계정명".ext 형태로 강제하는 step 추가

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -99,7 +99,7 @@ jobs:
               # 파일명이 GitHub계정명인지 확인
               shopt -s nocasematch
               if [[ ! "$filename" = "$pr_author"* ]]; then
-                echo "- $file (파일명은 '$pr_author'형식으로 해주셔야 합니다)" >> $GITHUB_STEP_SUMMARY
+                echo "- $file" >> $GITHUB_STEP_SUMMARY
                 success=false
               fi
             fi

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -108,7 +108,7 @@ jobs:
             echo "1. 파일 끝의 누락된 줄바꿈을 추가해 주세요." >> $GITHUB_STEP_SUMMARY
             echo "2. 파일명에서 제어문자를 제거해 주세요." >> $GITHUB_STEP_SUMMARY
             if [[ ! "$pr_labels" =~ "maintenance" ]]; then
-              echo "3. 파일명은 반드시 'GitHub계정명'형식으로 해주셔야 합니다. (예: ${pr_author}.ts)" >> $GITHUB_STEP_SUMMARY
+              echo "3. 파일명은 반드시 'GitHub계정명' 또는 'GitHub계정명-xxx' 형식으로 해주셔야 합니다. (예: ${pr_author}.ts, ${pr_author}-1.ts, ${pr_author}-2.ts)" >> $GITHUB_STEP_SUMMARY
             fi
             exit 1
           fi

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,8 +89,10 @@ jobs:
             echo -e "\n## 파일명 규칙 위반" >> $GITHUB_STEP_SUMMARY
             for file in $files; do
               if [ -f "$file" ]; then
+
                 # 파일명만 추출 (경로 제외)
                 filename=$(basename "$file")
+
                 # 파일명이 GitHub계정명인지 확인
                 shopt -s nocasematch
                 if [[ ! "$filename" = "$pr_author"* ]]; then

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,25 +25,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Check for 1. missing end line breaks and 2. control characters in filenames and 3. filename rules
+      # 줄바꿈 체크
+      - name: Check for missing end line breaks
         run: |
-          # 필요한 값들 미리 설정
-          pr_author="${{ github.event.pull_request.user.login }}"
-          pr_number="${{ github.event.pull_request.number }}"
-          labels_json=$(gh pr view $pr_number --json labels -q '.labels[].name')
-          has_maintenance=false
-          if echo "$labels_json" | grep -q "maintenance"; then
-            has_maintenance=true
-          fi
-
           # 따옴표를 제거하고 파일 목록 가져오기
           files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"')
+          success=true
+
           echo "변경된 파일 목록:"
           echo "$files"
 
-          success=true
-
-          # 줄바꿈 체크
           echo "## 줄바꿈 누락 파일" >> $GITHUB_STEP_SUMMARY
           for file in $files; do
             if [ -s "$file" ] && [ "$(tail -c 1 $file | wc -l)" -eq 0 ]; then
@@ -53,63 +44,69 @@ jobs:
             fi
           done
 
-          # 제어문자 체크
-          echo -e "\n## 제어문자가 포함된 파일명" >> $GITHUB_STEP_SUMMARY
+          if [ "$success" = false ]; then
+            echo -e "\n:warning: 파일 끝의 누락된 줄바꿈을 추가해 주세요." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+      # 제어문자 체크
+      - name: Check for control characters in filenames
+        run: |
+          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"')
+          success=true
+
+          echo "## 제어문자가 포함된 파일명" >> $GITHUB_STEP_SUMMARY
           for file in $files; do
             # basename으로 파일명만 추출하고 따옴표 제거
             filename=$(basename "$file" | tr -d '"')
 
             # 백슬래시로 시작하는 제어문자들 체크 (\b, \n, \r, \t 등)
-            if printf '%q' "$filename" | grep -q '\\[bnrtfv]'; then
-              echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
-              success=false
-            fi
+            if printf '%q' "$filename" | grep -q '\\[bnrtfv]' || \
 
-            # 일반적인 제어문자들 체크 (0x00-0x1F, 0x7F)
-            if echo -n "$filename" | LC_ALL=C grep -q '[[:cntrl:]]'; then
-              echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
-              success=false
-            fi
+               # 일반적인 제어문자들 체크 (0x00-0x1F, 0x7F)
+               echo -n "$filename" | LC_ALL=C grep -q '[[:cntrl:]]' || \
 
-            # 특수 제어문자들 체크
-            if echo -n "$filename" | grep -q $'[\x00-\x1F\x7F]'; then
-              echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
-              success=false
-            fi
+               # 특수 제어문자들 체크
+               echo -n "$filename" | grep -q $'[\x00-\x1F\x7F]' || \
 
-            # 이스케이프 시퀀스 체크
-            if [[ "$filename" =~ (\\[0-7]{1,3}|\\x[0-9a-fA-F]{1,2}) ]]; then
+               # 이스케이프 시퀀스 체크
+               [[ "$filename" =~ (\\[0-7]{1,3}|\\x[0-9a-fA-F]{1,2}) ]]; then
               echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
               success=false
             fi
           done
 
-          # maintenance 라벨이 없는 경우에만 파일명 규칙 체크
-          if [ "$has_maintenance" != "true" ]; then
-            echo -e "\n## 파일명 규칙 위반" >> $GITHUB_STEP_SUMMARY
-            for file in $files; do
-              if [ -f "$file" ]; then
-
-                # 파일명만 추출 (경로 제외)
-                filename=$(basename "$file")
-
-                # 파일명이 GitHub계정명인지 확인
-                shopt -s nocasematch
-                if [[ ! "$filename" = "$pr_author"* ]]; then
-                  echo "- $file (파일명은 '$pr_author'형식으로 해주셔야 합니다)" >> $GITHUB_STEP_SUMMARY
-                  success=false
-                fi
-              fi
-            done
+          if [ "$success" = false ]; then
+            echo -e "\n:warning: 파일명에서 제어문자를 제거해 주세요." >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
 
-          if [ "$success" = false ]; then
-            echo -e "\n:warning: 위 문제들을 해결해 주세요:" >> $GITHUB_STEP_SUMMARY
-            echo "1. 파일 끝의 누락된 줄바꿈을 추가해 주세요." >> $GITHUB_STEP_SUMMARY
-            echo "2. 파일명에서 제어문자를 제거해 주세요." >> $GITHUB_STEP_SUMMARY
-            if [[ ! "$pr_labels" =~ "maintenance" ]]; then
-              echo "3. 파일명은 반드시 'GitHub계정명' 또는 'GitHub계정명-xxx' 형식으로 해주셔야 합니다. (예: ${pr_author}.ts, ${pr_author}-1.ts, ${pr_author}-2.ts)" >> $GITHUB_STEP_SUMMARY
+      # 파일명 규칙 체크 - maintenance 라벨이 없는 경우에만 실행
+      - name: Check filename rules
+        if: ${{ steps.pr-labels.outputs.has_maintenance != 'true' }}
+        run: |
+          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"')
+          pr_author="${{ github.event.pull_request.user.login }}"
+          success=true
+
+          echo "## 파일명 규칙 위반" >> $GITHUB_STEP_SUMMARY
+          for file in $files; do
+            if [ -f "$file" ]; then
+
+              # 파일명만 추출 (경로 제외)
+              filename=$(basename "$file")
+
+              # 파일명이 GitHub계정명인지 확인
+              shopt -s nocasematch
+              if [[ ! "$filename" = "$pr_author"* ]]; then
+                echo "- $file (파일명은 '$pr_author'형식으로 해주셔야 합니다)" >> $GITHUB_STEP_SUMMARY
+                success=false
+              fi
             fi
+          done
+
+          if [ "$success" = false ]; then
+            echo -e "\n:warning: 파일명은 반드시 'GitHub계정명' 또는 'GitHub계정명-xxx' 형식으로 해주셔야 합니다. (예: ${pr_author}.ts, ${pr_author}-1.ts, ${pr_author}-2.ts)" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
         env:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,13 +11,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for 1. missing end line breaks and 2. control characters in filenames
+      # PR 라벨 확인
+      - name: Get PR labels
+        id: pr-labels
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels -q '.labels[].name' || echo "")
+          echo "labels=$labels" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check for 1. missing end line breaks and 2. control characters in filenames and 3. filename rules
         run: |
           # 따옴표를 제거하고 파일 목록 가져오기
           files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"')
           echo "변경된 파일 목록:"
           echo "$files"
-          
+
           success=true
 
           # 줄바꿈 체크
@@ -35,13 +44,13 @@ jobs:
           for file in $files; do
             # basename으로 파일명만 추출하고 따옴표 제거
             filename=$(basename "$file" | tr -d '"')
-            
+
             # 백슬래시로 시작하는 제어문자들 체크 (\b, \n, \r, \t 등)
             if printf '%q' "$filename" | grep -q '\\[bnrtfv]'; then
               echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
               success=false
             fi
-            
+
             # 일반적인 제어문자들 체크 (0x00-0x1F, 0x7F)
             if echo -n "$filename" | LC_ALL=C grep -q '[[:cntrl:]]'; then
               echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
@@ -53,7 +62,7 @@ jobs:
               echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
               success=false
             fi
-            
+
             # 이스케이프 시퀀스 체크
             if [[ "$filename" =~ (\\[0-7]{1,3}|\\x[0-9a-fA-F]{1,2}) ]]; then
               echo "- $file (제어문자 포함)" >> $GITHUB_STEP_SUMMARY
@@ -61,9 +70,29 @@ jobs:
             fi
           done
 
+          # maintenance 라벨이 없는 경우에만 파일명 규칙 체크
+          if [[ ! "${{ steps.pr-labels.outputs.labels }}" =~ "maintenance" ]]; then
+            echo -e "\n## 파일명 규칙 위반" >> $GITHUB_STEP_SUMMARY
+            for file in $files; do
+              if [ -f "$file" ]; then
+                filename=$(basename "$file" | tr -d '"')
+                github_username="${{ github.event.pull_request.user.login }}"
+
+                # 파일명이 GitHub계정명인지 확인
+                if [[ ! "$filename" =~ ^"$github_username" ]]; then
+                  echo "- $file (파일명은 '$github_username'로 해주셔야 합니다)" >> $GITHUB_STEP_SUMMARY
+                  success=false
+                fi
+              fi
+            done
+          fi
+
           if [ "$success" = false ]; then
             echo -e "\n:warning: 위 문제들을 해결해 주세요:" >> $GITHUB_STEP_SUMMARY
             echo "1. 파일 끝의 누락된 줄바꿈을 추가해 주세요." >> $GITHUB_STEP_SUMMARY
             echo "2. 파일명에서 제어문자를 제거해 주세요." >> $GITHUB_STEP_SUMMARY
+            if [[ ! "${{ steps.pr-labels.outputs.labels }}" =~ "maintenance" ]]; then
+              echo "3. 파일명은 반드시 'GitHub계정명'으로 해주셔야 합니다. (예: ${{ github.event.pull_request.user.login }}.ts)" >> $GITHUB_STEP_SUMMARY
+            fi
             exit 1
           fi

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -15,13 +15,27 @@ jobs:
       - name: Get PR labels
         id: pr-labels
         run: |
-          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels -q '.labels[].name' || echo "")
-          echo "labels=$labels" >> $GITHUB_OUTPUT
+          pr_number="${{ github.event.pull_request.number }}"
+          labels_json=$(gh pr view $pr_number --json labels -q '.labels[].name')
+          if [ -n "$labels_json" ]; then
+            echo "has_maintenance=$(echo $labels_json | grep -q 'maintenance' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          else
+            echo "has_maintenance=false" >> $GITHUB_OUTPUT
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Check for 1. missing end line breaks and 2. control characters in filenames and 3. filename rules
         run: |
+          # 필요한 값들 미리 설정
+          pr_author="${{ github.event.pull_request.user.login }}"
+          pr_number="${{ github.event.pull_request.number }}"
+          labels_json=$(gh pr view $pr_number --json labels -q '.labels[].name')
+          has_maintenance=false
+          if echo "$labels_json" | grep -q "maintenance"; then
+            has_maintenance=true
+          fi
+
           # 따옴표를 제거하고 파일 목록 가져오기
           files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"')
           echo "변경된 파일 목록:"
@@ -71,16 +85,16 @@ jobs:
           done
 
           # maintenance 라벨이 없는 경우에만 파일명 규칙 체크
-          if [[ ! "${{ steps.pr-labels.outputs.labels }}" =~ "maintenance" ]]; then
+          if [ "$has_maintenance" != "true" ]; then
             echo -e "\n## 파일명 규칙 위반" >> $GITHUB_STEP_SUMMARY
             for file in $files; do
               if [ -f "$file" ]; then
-                filename=$(basename "$file" | tr -d '"')
-                github_username="${{ github.event.pull_request.user.login }}"
-
+                # 파일명만 추출 (경로 제외)
+                filename=$(basename "$file")
                 # 파일명이 GitHub계정명인지 확인
-                if [[ ! "$filename" =~ ^"$github_username" ]]; then
-                  echo "- $file (파일명은 '$github_username'로 해주셔야 합니다)" >> $GITHUB_STEP_SUMMARY
+                shopt -s nocasematch
+                if [[ ! "$filename" = "$pr_author"* ]]; then
+                  echo "- $file (파일명은 '$pr_author'형식으로 해주셔야 합니다)" >> $GITHUB_STEP_SUMMARY
                   success=false
                 fi
               fi
@@ -91,8 +105,10 @@ jobs:
             echo -e "\n:warning: 위 문제들을 해결해 주세요:" >> $GITHUB_STEP_SUMMARY
             echo "1. 파일 끝의 누락된 줄바꿈을 추가해 주세요." >> $GITHUB_STEP_SUMMARY
             echo "2. 파일명에서 제어문자를 제거해 주세요." >> $GITHUB_STEP_SUMMARY
-            if [[ ! "${{ steps.pr-labels.outputs.labels }}" =~ "maintenance" ]]; then
-              echo "3. 파일명은 반드시 'GitHub계정명'으로 해주셔야 합니다. (예: ${{ github.event.pull_request.user.login }}.ts)" >> $GITHUB_STEP_SUMMARY
+            if [[ ! "$pr_labels" =~ "maintenance" ]]; then
+              echo "3. 파일명은 반드시 'GitHub계정명'형식으로 해주셔야 합니다. (예: ${pr_author}.ts)" >> $GITHUB_STEP_SUMMARY
             fi
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## 목적

- 멤버분들께서 답안을 제출하실 때, 파일명을 "계정명.확장자" 형태로 강제하기 위한 CI 스텝을 추가합니다.

## 동작 예시

### 올바른 파일명 사용시(HC-kang.js)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b18b1793-313f-4766-85a1-98ea0ea721e5">

### 올바르지 않은 파일명 사용시(hckang.js)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4e367b9e-f286-4531-96c5-20c9b24e8154">

## 예외사항

종종 아래와 같은 경우가 발생할 수 있습니다.

1. 답안 제출목적이 아닌, 워크플로우 수정이나 스크립트 추가 등의 작업이 필요한 경우
2. 필요에 따라 다른 사람의 답안을 수정해야 하는 경우

### 예시

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e39e0ccf-99fa-40fd-957b-a980e6d0fb3e">

이러한 경우 `maintenance` 라벨을 사용하시면 해당 파일명 검증 스텝을 우회 할수 있습니다.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7f2e57f1-027a-4b11-8acc-0d9fcc89436e">

## 기타

- 안내문구 자체는 파일명이 계정명과 일치하는 형태로 표현되고있으나, 사실 Prefix로 동작합니다.
- 대소문자는 구별하지 않습니다. (hc-kang, Hc-KaNg... 등 모두 허용)
