### PR TITLE
fix(integration): Fix filename validation to compare with PR base SHA instead of latest branch

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Check filename rules
         if: ${{ steps.pr-labels.outputs.has_maintenance != 'true' }}
         run: |
-          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr -d '"')
+          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | tr -d '"')
           pr_author="${{ github.event.pull_request.user.login }}"
           success=true
 


### PR DESCRIPTION
추가된 파일을 확인하기 위해 `diff` 할 때, 자신의 부모가 아니라 최신 브랜치와 비교하고 있었습니다.
이로인해 중간에 누군가 다른 멤버분께서 머지하시는 경우, 통합할 수 없는 상태가 되고있었네요.