### PR TITLE
CODEOWNERS 파일 삭제

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @DaleStudy/coach


### PR DESCRIPTION
4기는 코치진이 없어서 자동으로 coach 팀이 PR에 리뷰어로 추가되지 않도록 CODEOWNERS 파일을 삭제합니다.