### PR TITLE
feat: add blindCategories field to problem-categories.json

### DIFF
--- a/problem-categories.json
+++ b/problem-categories.json
@@ -6,6 +6,9 @@
       "Two Pointers",
       "Sorting"
     ],
+    "blindCategories": [
+      "Array"
+    ],
     "intended_approach": "배열을 정렬한 뒤, 각 원소를 기준으로 투 포인터를 사용해 O(n²)으로 풀어야 합니다."
   },
   "alien-dictionary": {
@@ -18,6 +21,9 @@
       "Graph Theory",
       "Topological Sort"
     ],
+    "blindCategories": [
+      "Graph"
+    ],
     "intended_approach": "인접한 단어 쌍에서 문자 순서 관계를 엣지로 추출하고, 위상 정렬(BFS/DFS)로 순서를 결정합니다."
   },
   "best-time-to-buy-and-sell-stock": {
@@ -25,6 +31,9 @@
     "categories": [
       "Array",
       "Dynamic Programming"
+    ],
+    "blindCategories": [
+      "Array"
     ],
     "intended_approach": "한 번의 순회로 최솟값을 추적하면서 현재 가격과의 차이를 계산합니다. O(n), O(1)."
   },
@@ -34,6 +43,9 @@
       "Tree",
       "Breadth-First Search",
       "Binary Tree"
+    ],
+    "blindCategories": [
+      "Tree"
     ],
     "intended_approach": "큐를 사용한 BFS로 레벨별로 노드를 처리합니다."
   },
@@ -45,6 +57,9 @@
       "Depth-First Search",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "DFS로 각 노드에서의 최대 gain을 계산하고, 좌우 자식을 포함한 경로 합을 전역 최댓값과 비교합니다."
   },
   "climbing-stairs": {
@@ -53,6 +68,9 @@
       "Math",
       "Dynamic Programming",
       "Memoization"
+    ],
+    "blindCategories": [
+      "Dynamic Programming"
     ],
     "intended_approach": "dp[i] = dp[i-1] + dp[i-2] 피보나치 점화식으로 풀어야 합니다."
   },
@@ -64,6 +82,9 @@
       "Breadth-First Search",
       "Graph Theory"
     ],
+    "blindCategories": [
+      "Graph"
+    ],
     "intended_approach": "HashMap으로 원본 노드와 복제 노드를 매핑하면서 BFS 또는 DFS로 순회합니다."
   },
   "coin-change": {
@@ -73,6 +94,9 @@
       "Dynamic Programming",
       "Breadth-First Search"
     ],
+    "blindCategories": [
+      "Dynamic Programming"
+    ],
     "intended_approach": "dp[i] = amount i를 만드는 최소 동전 수로 정의하고, Bottom-up DP로 풀어야 합니다."
   },
   "combination-sum": {
@@ -80,6 +104,9 @@
     "categories": [
       "Array",
       "Backtracking"
+    ],
+    "blindCategories": [
+      "Dynamic Programming"
     ],
     "intended_approach": "백트래킹으로 후보 목록을 탐색하고, 중복 사용을 허용하기 위해 현재 인덱스부터 재귀합니다."
   },
@@ -92,6 +119,9 @@
       "Tree",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "preorder의 첫 원소가 루트이고, inorder에서 루트 위치를 HashMap으로 O(1) 조회해 재귀적으로 트리를 구성합니다."
   },
   "container-with-most-water": {
@@ -100,6 +130,9 @@
       "Array",
       "Two Pointers",
       "Greedy"
+    ],
+    "blindCategories": [
+      "Array"
     ],
     "intended_approach": "양 끝에서 시작해 더 짧은 쪽 포인터를 이동하는 투 포인터로 O(n)에 풀어야 합니다."
   },
@@ -110,6 +143,9 @@
       "Hash Table",
       "Sorting"
     ],
+    "blindCategories": [
+      "Array"
+    ],
     "intended_approach": "HashSet에 원소를 추가하면서 이미 존재하는지 확인합니다. O(n), O(n)."
   },
   "counting-bits": {
@@ -117,6 +153,9 @@
     "categories": [
       "Dynamic Programming",
       "Bit Manipulation"
+    ],
+    "blindCategories": [
+      "Binary"
     ],
     "intended_approach": "dp[i] = dp[i >> 1] + (i & 1) 점화식을 활용해 O(n)으로 풀어야 합니다."
   },
@@ -128,12 +167,18 @@
       "Graph Theory",
       "Topological Sort"
     ],
+    "blindCategories": [
+      "Graph"
+    ],
     "intended_approach": "방향 그래프에서 사이클 존재 여부를 DFS(색칠 기법) 또는 BFS 위상 정렬로 감지합니다."
   },
   "decode-ways": {
     "difficulty": "Medium",
     "categories": [
       "String",
+      "Dynamic Programming"
+    ],
+    "blindCategories": [
       "Dynamic Programming"
     ],
     "intended_approach": "dp[i] = s[:i]를 디코딩하는 경우의 수로 정의하고, 1자리/2자리 해석 가능 여부에 따라 Bottom-up DP로 풀어야 합니다."
@@ -146,6 +191,9 @@
       "Design",
       "Trie"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "Trie를 구현하고, '.' 와일드카드 처리를 위해 DFS로 모든 자식 노드를 탐색합니다."
   },
   "encode-and-decode-strings": {
@@ -154,6 +202,9 @@
       "Array",
       "String",
       "Design"
+    ],
+    "blindCategories": [
+      "String"
     ],
     "intended_approach": "각 문자열 앞에 길이를 접두사로 붙이는 방식(예: '4#word')으로 구분자 충돌 없이 인코딩/디코딩합니다."
   },
@@ -166,6 +217,9 @@
       "Heap (Priority Queue)",
       "Data Stream"
     ],
+    "blindCategories": [
+      "Heap"
+    ],
     "intended_approach": "최대 힙(작은 절반)과 최소 힙(큰 절반)을 유지하며 중앙값을 O(log n)에 구합니다."
   },
   "find-minimum-in-rotated-sorted-array": {
@@ -173,6 +227,9 @@
     "categories": [
       "Array",
       "Binary Search"
+    ],
+    "blindCategories": [
+      "Array"
     ],
     "intended_approach": "이진 탐색으로 정렬된 절반을 판별해 O(log n)에 최솟값을 찾아야 합니다."
   },
@@ -184,6 +241,9 @@
       "Union-Find",
       "Graph Theory"
     ],
+    "blindCategories": [
+      "Graph"
+    ],
     "intended_approach": "Union-Find 또는 DFS로 사이클 여부를 확인하고, 모든 노드가 연결되어 있는지 검증합니다."
   },
   "group-anagrams": {
@@ -194,6 +254,9 @@
       "String",
       "Sorting"
     ],
+    "blindCategories": [
+      "String"
+    ],
     "intended_approach": "정렬된 문자열 또는 문자 카운팅 튜플을 HashMap의 키로 사용해 그룹핑합니다."
   },
   "house-robber": {
@@ -202,12 +265,18 @@
       "Array",
       "Dynamic Programming"
     ],
+    "blindCategories": [
+      "Dynamic Programming"
+    ],
     "intended_approach": "dp[i] = max(dp[i-1], dp[i-2] + nums[i]) 점화식으로 O(n), O(1) DP로 풀어야 합니다."
   },
   "house-robber-ii": {
     "difficulty": "Medium",
     "categories": [
       "Array",
+      "Dynamic Programming"
+    ],
+    "blindCategories": [
       "Dynamic Programming"
     ],
     "intended_approach": "원형 배열을 첫 집 포함/제외 두 경우로 분리해 house-robber를 두 번 실행합니다."
@@ -220,12 +289,18 @@
       "Design",
       "Trie"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "각 노드가 자식 맵과 is_end 플래그를 갖는 Trie 자료구조를 직접 구현합니다."
   },
   "insert-interval": {
     "difficulty": "Medium",
     "categories": [
       "Array"
+    ],
+    "blindCategories": [
+      "Interval"
     ],
     "intended_approach": "새 구간의 앞/겹치는/뒤 세 구역으로 나눠 선형 순회로 O(n)에 처리합니다."
   },
@@ -237,6 +312,9 @@
       "Breadth-First Search",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "DFS 재귀 또는 BFS로 각 노드의 좌우 자식을 교환합니다."
   },
   "jump-game": {
@@ -245,6 +323,9 @@
       "Array",
       "Dynamic Programming",
       "Greedy"
+    ],
+    "blindCategories": [
+      "Dynamic Programming"
     ],
     "intended_approach": "현재까지 도달 가능한 최대 인덱스를 추적하는 Greedy로 O(n)에 풀어야 합니다."
   },
@@ -256,6 +337,9 @@
       "Binary Search Tree",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "BST의 중위 순회(In-order traversal)는 오름차순이므로 k번째 원소가 정답입니다."
   },
   "linked-list-cycle": {
@@ -265,12 +349,18 @@
       "Linked List",
       "Two Pointers"
     ],
+    "blindCategories": [
+      "Linked List"
+    ],
     "intended_approach": "플로이드 사이클 감지(빠른/느린 포인터)로 O(n), O(1)에 풀어야 합니다."
   },
   "longest-common-subsequence": {
     "difficulty": "Medium",
     "categories": [
       "String",
+      "Dynamic Programming"
+    ],
+    "blindCategories": [
       "Dynamic Programming"
     ],
     "intended_approach": "2D DP 테이블 dp[i][j] = text1[:i]와 text2[:j]의 LCS 길이로 풀어야 합니다."
@@ -282,6 +372,9 @@
       "Hash Table",
       "Union-Find"
     ],
+    "blindCategories": [
+      "Graph"
+    ],
     "intended_approach": "HashSet에 모든 수를 넣고, 시퀀스 시작점(num-1이 없는 수)에서만 연속 길이를 셉니다. O(n)."
   },
   "longest-increasing-subsequence": {
@@ -289,6 +382,9 @@
     "categories": [
       "Array",
       "Binary Search",
+      "Dynamic Programming"
+    ],
+    "blindCategories": [
       "Dynamic Programming"
     ],
     "intended_approach": "O(n log n)은 이진 탐색으로 patience sorting, O(n²)은 기본 DP로 풀어야 합니다."
@@ -300,6 +396,9 @@
       "String",
       "Dynamic Programming"
     ],
+    "blindCategories": [
+      "String"
+    ],
     "intended_approach": "각 문자(및 문자 사이)를 중심으로 확장하는 중심 확장법으로 O(n²), O(1)에 풀어야 합니다."
   },
   "longest-repeating-character-replacement": {
@@ -309,6 +408,9 @@
       "String",
       "Sliding Window"
     ],
+    "blindCategories": [
+      "String"
+    ],
     "intended_approach": "슬라이딩 윈도우로 윈도우 내 최다 빈도 문자를 추적하고, (window 크기 - 최다 빈도) ≤ k 조건을 유지합니다."
   },
   "longest-substring-without-repeating-characters": {
@@ -317,6 +419,9 @@
       "Hash Table",
       "String",
       "Sliding Window"
+    ],
+    "blindCategories": [
+      "String"
     ],
     "intended_approach": "슬라이딩 윈도우 + HashMap으로 중복 문자 발생 시 왼쪽 포인터를 이동합니다. O(n)."
   },
@@ -328,6 +433,9 @@
       "Binary Search Tree",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "BST 속성(p, q가 모두 왼쪽/오른쪽이면 내려가고, 분기되면 현재 노드가 LCA)을 활용해 재귀합니다."
   },
   "maximum-depth-of-binary-tree": {
@@ -338,6 +446,9 @@
       "Breadth-First Search",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "DFS 재귀로 max(left, right) + 1을 반환하거나 BFS로 레벨을 셉니다."
   },
   "maximum-product-subarray": {
@@ -345,6 +456,9 @@
     "categories": [
       "Array",
       "Dynamic Programming"
+    ],
+    "blindCategories": [
+      "Array"
     ],
     "intended_approach": "음수 곱셈을 고려해 현재 최댓값과 최솟값을 동시에 추적하는 DP로 풀어야 합니다."
   },
@@ -355,6 +469,9 @@
       "Divide and Conquer",
       "Dynamic Programming"
     ],
+    "blindCategories": [
+      "Array"
+    ],
     "intended_approach": "카데인 알고리즘: 현재 합이 음수가 되면 초기화하는 방식으로 O(n), O(1)에 풀어야 합니다."
   },
   "meeting-rooms": {
@@ -362,6 +479,9 @@
     "categories": [
       "Array",
       "Sorting"
+    ],
+    "blindCategories": [
+      "Interval"
     ],
     "intended_approach": "시작 시간 기준으로 정렬 후, 인접한 회의의 겹침 여부를 확인합니다."
   },
@@ -375,6 +495,9 @@
       "Heap (Priority Queue)",
       "Prefix Sum"
     ],
+    "blindCategories": [
+      "Interval"
+    ],
     "intended_approach": "최소 힙으로 진행 중인 회의의 종료 시간을 관리하고, 새 회의가 시작될 때 가장 빨리 끝나는 회의와 비교합니다."
   },
   "merge-intervals": {
@@ -382,6 +505,9 @@
     "categories": [
       "Array",
       "Sorting"
+    ],
+    "blindCategories": [
+      "Interval"
     ],
     "intended_approach": "시작 시간으로 정렬 후 선형 순회하며 이전 구간과 겹치면 병합합니다."
   },
@@ -393,6 +519,10 @@
       "Heap (Priority Queue)",
       "Merge Sort"
     ],
+    "blindCategories": [
+      "Linked List",
+      "Heap"
+    ],
     "intended_approach": "최소 힙(Priority Queue)에 각 리스트의 헤드를 넣고 순서대로 추출합니다. O(n log k)."
   },
   "merge-two-sorted-lists": {
@@ -400,6 +530,9 @@
     "categories": [
       "Linked List",
       "Recursion"
+    ],
+    "blindCategories": [
+      "Linked List"
     ],
     "intended_approach": "두 포인터로 작은 쪽을 연결하는 반복 또는 재귀로 풀어야 합니다."
   },
@@ -409,6 +542,9 @@
       "Hash Table",
       "String",
       "Sliding Window"
+    ],
+    "blindCategories": [
+      "String"
     ],
     "intended_approach": "슬라이딩 윈도우 + 문자 카운팅 HashMap으로, 조건 충족 시 윈도우를 줄이며 최솟값을 갱신합니다."
   },
@@ -422,6 +558,9 @@
       "Bit Manipulation",
       "Sorting"
     ],
+    "blindCategories": [
+      "Binary"
+    ],
     "intended_approach": "XOR(모든 수 XOR 인덱스) 또는 가우스 공식(n*(n+1)/2 - 합)으로 O(n), O(1)에 풀어야 합니다."
   },
   "non-overlapping-intervals": {
@@ -432,6 +571,9 @@
       "Greedy",
       "Sorting"
     ],
+    "blindCategories": [
+      "Interval"
+    ],
     "intended_approach": "종료 시간 기준으로 정렬 후, Greedy로 겹치는 구간 중 종료 시간이 긴 쪽을 제거합니다."
   },
   "number-of-1-bits": {
@@ -439,6 +581,9 @@
     "categories": [
       "Divide and Conquer",
       "Bit Manipulation"
+    ],
+    "blindCategories": [
+      "Binary"
     ],
     "intended_approach": "n & (n-1)로 가장 낮은 1 비트를 제거하는 방식으로 set bit 수를 셉니다."
   },
@@ -449,6 +594,9 @@
       "Breadth-First Search",
       "Union-Find",
       "Graph Theory"
+    ],
+    "blindCategories": [
+      "Graph"
     ],
     "intended_approach": "Union-Find 또는 DFS/BFS로 연결 컴포넌트 수를 셉니다."
   },
@@ -461,6 +609,9 @@
       "Union-Find",
       "Matrix"
     ],
+    "blindCategories": [
+      "Graph"
+    ],
     "intended_approach": "육지 셀을 발견하면 DFS/BFS로 연결된 육지를 모두 방문 처리하고 카운트합니다."
   },
   "pacific-atlantic-water-flow": {
@@ -471,6 +622,9 @@
       "Breadth-First Search",
       "Matrix"
     ],
+    "blindCategories": [
+      "Graph"
+    ],
     "intended_approach": "역방향으로 태평양/대서양 경계에서 DFS/BFS를 시작해 도달 가능한 셀의 교집합을 구합니다."
   },
   "palindromic-substrings": {
@@ -480,6 +634,9 @@
       "String",
       "Dynamic Programming"
     ],
+    "blindCategories": [
+      "String"
+    ],
     "intended_approach": "각 문자와 문자 사이를 중심으로 확장하는 중심 확장법으로 O(n²)에 팰린드롬 수를 셉니다."
   },
   "product-of-array-except-self": {
@@ -488,6 +645,9 @@
       "Array",
       "Prefix Sum"
     ],
+    "blindCategories": [
+      "Array"
+    ],
     "intended_approach": "나눗셈 없이 prefix 곱 배열과 suffix 곱을 활용해 O(n), O(1) 추가 공간으로 풀어야 합니다."
   },
   "remove-nth-node-from-end-of-list": {
@@ -495,6 +655,9 @@
     "categories": [
       "Linked List",
       "Two Pointers"
+    ],
+    "blindCategories": [
+      "Linked List"
     ],
     "intended_approach": "빠른 포인터를 n+1 앞서 출발시키는 투 포인터로 한 번의 순회에 처리합니다."
   },
@@ -506,6 +669,9 @@
       "Stack",
       "Recursion"
     ],
+    "blindCategories": [
+      "Linked List"
+    ],
     "intended_approach": "중간 찾기(느린/빠른 포인터) → 후반 역전 → 교차 병합 세 단계로 풀어야 합니다."
   },
   "reverse-bits": {
@@ -513,6 +679,9 @@
     "categories": [
       "Divide and Conquer",
       "Bit Manipulation"
+    ],
+    "blindCategories": [
+      "Binary"
     ],
     "intended_approach": "비트를 하나씩 추출해 결과에 왼쪽으로 추가하는 비트 시프트 연산으로 풀어야 합니다."
   },
@@ -522,6 +691,9 @@
       "Linked List",
       "Recursion"
     ],
+    "blindCategories": [
+      "Linked List"
+    ],
     "intended_approach": "prev/curr 포인터로 방향을 뒤집는 반복(O(1) 공간) 또는 재귀로 풀어야 합니다."
   },
   "rotate-image": {
@@ -529,6 +701,9 @@
     "categories": [
       "Array",
       "Math",
+      "Matrix"
+    ],
+    "blindCategories": [
       "Matrix"
     ],
     "intended_approach": "전치(Transpose) 후 각 행을 좌우 반전하면 O(1) 추가 공간으로 90도 회전됩니다."
@@ -541,6 +716,9 @@
       "Breadth-First Search",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "두 트리를 동시에 DFS 재귀로 순회하며 값과 구조를 비교합니다."
   },
   "search-in-rotated-sorted-array": {
@@ -548,6 +726,9 @@
     "categories": [
       "Array",
       "Binary Search"
+    ],
+    "blindCategories": [
+      "Array"
     ],
     "intended_approach": "이진 탐색에서 mid를 기준으로 좌/우 절반 중 정렬된 쪽을 판별해 탐색 범위를 줄입니다."
   },
@@ -561,6 +742,9 @@
       "Design",
       "Binary Tree"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "BFS(레벨 순서) 또는 DFS 전위 순회로 직렬화하고, null 마커로 구조를 복원합니다."
   },
   "set-matrix-zeroes": {
@@ -568,6 +752,9 @@
     "categories": [
       "Array",
       "Hash Table",
+      "Matrix"
+    ],
+    "blindCategories": [
       "Matrix"
     ],
     "intended_approach": "첫 행/열을 마커 행으로 활용해 O(1) 추가 공간으로 풀어야 합니다."
@@ -578,6 +765,9 @@
       "Array",
       "Matrix",
       "Simulation"
+    ],
+    "blindCategories": [
+      "Matrix"
     ],
     "intended_approach": "상/하/좌/우 경계를 좁혀가며 시뮬레이션으로 순회합니다."
   },
@@ -590,6 +780,9 @@
       "Binary Tree",
       "Hash Function"
     ],
+    "blindCategories": [
+      "Tree"
+    ],
     "intended_approach": "각 노드에서 same-tree 판별 함수를 호출하는 DFS로 풀어야 합니다."
   },
   "sum-of-two-integers": {
@@ -597,6 +790,9 @@
     "categories": [
       "Math",
       "Bit Manipulation"
+    ],
+    "blindCategories": [
+      "Binary"
     ],
     "intended_approach": "XOR로 합(올림 없는 덧셈), AND 후 왼쪽 시프트로 올림을 계산하고 올림이 0이 될 때까지 반복합니다."
   },
@@ -612,6 +808,9 @@
       "Counting",
       "Quickselect"
     ],
+    "blindCategories": [
+      "Heap"
+    ],
     "intended_approach": "버킷 정렬(빈도를 인덱스로 사용)로 O(n)에 풀거나, 최소 힙으로 O(n log k)에 풀어야 합니다."
   },
   "two-sum": {
@@ -619,6 +818,9 @@
     "categories": [
       "Array",
       "Hash Table"
+    ],
+    "blindCategories": [
+      "Array"
     ],
     "intended_approach": "HashMap으로 target - nums[i]를 조회하며 한 번의 순회로 O(n)에 풀어야 합니다."
   },
@@ -629,6 +831,9 @@
       "Dynamic Programming",
       "Combinatorics"
     ],
+    "blindCategories": [
+      "Dynamic Programming"
+    ],
     "intended_approach": "dp[i][j] = dp[i-1][j] + dp[i][j-1]로 2D DP, 또는 조합 C(m+n-2, m-1)으로 수학적으로 풀 수 있습니다."
   },
   "valid-anagram": {
@@ -638,12 +843,18 @@
       "String",
       "Sorting"
     ],
+    "blindCategories": [
+      "String"
+    ],
     "intended_approach": "문자 카운팅 배열(26) 또는 HashMap으로 두 문자열의 빈도를 비교합니다."
   },
   "valid-palindrome": {
     "difficulty": "Easy",
     "categories": [
       "Two Pointers",
+      "String"
+    ],
+    "blindCategories": [
       "String"
     ],
     "intended_approach": "양 끝에서 시작하는 투 포인터로 영숫자만 비교합니다. O(n), O(1)."
@@ -654,6 +865,9 @@
       "String",
       "Stack"
     ],
+    "blindCategories": [
+      "String"
+    ],
     "intended_approach": "스택을 사용해 여는 괄호를 push하고, 닫는 괄호가 나오면 스택 top과 대응 여부를 확인합니다."
   },
   "validate-binary-search-tree": {
@@ -663,6 +877,9 @@
       "Depth-First Search",
       "Binary Search Tree",
       "Binary Tree"
+    ],
+    "blindCategories": [
+      "Tree"
     ],
     "intended_approach": "DFS로 각 노드에 유효 범위(min, max)를 전달하며 BST 조건을 검증합니다."
   },
@@ -676,6 +893,9 @@
       "Trie",
       "Memoization"
     ],
+    "blindCategories": [
+      "Dynamic Programming"
+    ],
     "intended_approach": "dp[i] = s[:i]가 wordDict로 분리 가능한지 여부로 정의하고, Bottom-up DP로 O(n²)에 풀어야 합니다."
   },
   "word-search": {
@@ -685,6 +905,9 @@
       "String",
       "Backtracking",
       "Depth-First Search",
+      "Matrix"
+    ],
+    "blindCategories": [
       "Matrix"
     ],
     "intended_approach": "각 셀에서 DFS 백트래킹으로 탐색하고, 방문한 셀을 임시 마킹해 중복 방문을 방지합니다."
@@ -697,6 +920,9 @@
       "Backtracking",
       "Trie",
       "Matrix"
+    ],
+    "blindCategories": [
+      "Tree"
     ],
     "intended_approach": "단어 목록으로 Trie를 구성하고, 그리드를 DFS 백트래킹으로 탐색하며 Trie 노드와 함께 매칭합니다."
   }


### PR DESCRIPTION
## Summary

각 문제에 **Blind Top 75 큐레이션 기준 카테고리**를 `blindCategories` 필드로 추가합니다.

[Blind 포스트 원문](https://www.teamblind.com/post/new-year-gift-curated-list-of-top-75-leetcode-questions-to-save-your-time-oam1oreu) 기준 10개 카테고리 중 하나 이상에 매핑:

> Array, Binary, Dynamic Programming, Graph, Interval, Linked List, Matrix, String, Tree, Heap

예시:
```json
"two-sum": {
  "difficulty": "Easy",
  "categories": ["Array", "Hash Table"],
  "blindCategories": ["Array"],
  "intended_approach": "..."
}
```

`merge-k-sorted-lists` 는 Linked List + Heap 두 카테고리 동시 소속 (Blind 포스트 기준).

## 왜?

관련 이슈: https://github.com/DaleStudy/github/issues/34

현재 GitHub App (`github.dalestudy.com`) 이 PR 댓글로 출력하는 "문제 풀이 현황" 표가 LeetCode 기준 20+개 카테고리로 너무 길다는 피드백. Blind 10개 카테고리로 축소하려고 하는데, 매핑 정보를 Worker 코드에 하드코딩하면 문제 메타데이터가 두 레포에 분산되므로 **원본 JSON 을 단일 소스로** 확장.

## 카테고리별 문제 수 (검증)

| Blind 카테고리 | 문제 수 |
|---|---:|
| Array | 10 |
| Binary | 5 |
| Dynamic Programming | 11 |
| Graph | 8 |
| Interval | 5 |
| Linked List | 6 |
| Matrix | 4 |
| String | 10 |
| Tree | 14 |
| Heap | 3 |

75개 문제 전부 매핑 (합계 76 = 75 + merge-k-sorted-lists 의 Linked List/Heap 중복 1).

## 영향 범위

- 기존 필드(difficulty, categories, intended_approach) 는 건드리지 않음. 순수 추가.
- 인덴트(2-space), 키 순서 유지 → diff 는 226줄 순수 insertion.

## Test plan

- [x] 모든 75개 문제가 blindCategories 필드를 가지는지 확인
- [x] 합계가 Blind 포스트와 일치 (10/5/11/8/5/6/4/10/14/3)
- [ ] 병합 후 DaleStudy/github PR #37 머지 → 프로덕션 PR 댓글에서 10행으로 노출되는지 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)